### PR TITLE
Fix license metadata in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1507,7 +1507,7 @@ def main():
             f"Programming Language :: Python :: 3.{i}"
             for i in range(python_min_version[1], version_range_max)
         ],
-        license="BSD-3",
+        license="BSD-3-Clause",
         keywords="pytorch, machine learning",
     )
     if EMIT_BUILD_WARNING:


### PR DESCRIPTION
Package metadata in `setup.py` lists license as `BSD-3` which is not a valid SPDX id.
The correct id would be `BSD-3-Clause`.